### PR TITLE
fix: WriteString: write byte count, not string length

### DIFF
--- a/BeatTogether.Core.Messaging/Extensions/SpanBufferWriterExtensions.cs
+++ b/BeatTogether.Core.Messaging/Extensions/SpanBufferWriterExtensions.cs
@@ -36,7 +36,7 @@ namespace BeatTogether.Extensions
 
         public static void WriteString(this ref SpanBufferWriter bufferWriter, string value)
         {
-            bufferWriter.WriteInt32(value.Length);
+            bufferWriter.WriteInt32(Encoding.UTF8.GetByteCount(value));
             bufferWriter.WriteBytes(Encoding.UTF8.GetBytes(value));
         }
 


### PR DESCRIPTION
This fixes issues with emojis and other special characters (https://github.com/pythonology/BeatTogether/issues/9)