### PR TITLE
feat: version specific messages / protocol v3

### DIFF
--- a/BeatTogether.Core.Messaging/Abstractions/IVersionedMessage.cs
+++ b/BeatTogether.Core.Messaging/Abstractions/IVersionedMessage.cs
@@ -1,0 +1,10 @@
+using Krypton.Buffers;
+
+namespace BeatTogether.Core.Messaging.Abstractions
+{
+    public interface IVersionedMessage
+    {
+        void WriteTo(ref SpanBufferWriter bufferWriter, uint protocolVersion);
+        void ReadFrom(ref SpanBufferReader bufferReader, uint protocolVersion);
+    }
+}

--- a/BeatTogether.Core.Messaging/Implementations/MessageReader.cs
+++ b/BeatTogether.Core.Messaging/Implementations/MessageReader.cs
@@ -49,7 +49,12 @@ namespace BeatTogether.Core.Messaging.Implementations
                 request.RequestId = bufferReader.ReadUInt32();
             if (message is IResponse response)
                 response.ResponseId = bufferReader.ReadUInt32();
-            message.ReadFrom(ref bufferReader);
+            
+            if (message is IVersionedMessage versionedMessage)
+                versionedMessage.ReadFrom(ref bufferReader, protocolVersion);
+            else
+                message.ReadFrom(ref bufferReader);
+            
             return message;
         }
     }

--- a/BeatTogether.Core.Messaging/Implementations/MessageWriter.cs
+++ b/BeatTogether.Core.Messaging/Implementations/MessageWriter.cs
@@ -9,7 +9,7 @@ namespace BeatTogether.Core.Messaging.Implementations
 {
     public class MessageWriter : IMessageWriter
     {
-        protected virtual uint ProtocolVersion => 1;
+        protected virtual uint ProtocolVersion => 3;
 
         private readonly Dictionary<uint, IMessageRegistry> _messageRegistries;
 
@@ -51,7 +51,12 @@ namespace BeatTogether.Core.Messaging.Implementations
                 messageBufferWriter.WriteUInt32(request.RequestId);
             if (message is IResponse response)
                 messageBufferWriter.WriteUInt32(response.ResponseId);
-            message.WriteTo(ref messageBufferWriter);
+            
+            if (message is IVersionedMessage versionedMessage)
+                versionedMessage.WriteTo(ref messageBufferWriter, ProtocolVersion);
+            else
+                message.WriteTo(ref messageBufferWriter);
+            
             bufferWriter.WriteVarUInt((uint)messageBufferWriter.Size);
             // TODO: Remove byte array allocation
             bufferWriter.WriteBytes(messageBufferWriter.Data.ToArray());


### PR DESCRIPTION
This PR adds support for master server protocol v3 messages.

This fixes an issue where joining clients cannot see the lobby code:
pythonology/BeatTogether#19

https://github.com/pythonology/BeatTogether.MasterServer/pull/8 depends on this PR